### PR TITLE
[Feature] Semver Ranges

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -409,3 +409,28 @@ TEST_CASE("from/to string") {
     REQUIRE(!semver::valid("1.2"));
   }
 }
+
+TEST_CASE("ranges") {
+  SECTION("basic") {
+    
+    struct TestCase {
+      std::string range;
+      version ver;
+      bool contains;
+    };
+ 
+    std::vector<TestCase> tests = {
+      {"> 1.2.3", {1, 2, 5}, true},
+      {"> 1.2.3", {1, 1, 0}, false},
+      {">=1.2.0 <2.0.0", {1, 2, 5}, true},
+      {">=1.2.0 <2.0.0", {2, 3, 0}, false},
+      {"1.0.0", {1, 0, 0}, true},
+      {"1.0.0 < 2.0.0", {1, 5, 0}, false}
+    };
+ 
+    for (const auto& test : tests) {
+      range range(test.range);
+      REQUIRE(range.contains(test.ver) == test.contains);
+    }
+  }
+}


### PR DESCRIPTION
[Work in progress]

It's a draft implementation of semver [ranges](https://github.com/npm/node-semver#ranges). It's already supports basic range comparators like

- `>=1.2.7`
-  `>=1.2.0 <=2.3.4`

**Example**

```
const semver::range range(">= 1.2.4 < 2.0.0");
constexpr semver::version version = "1.5.2"_version;
if (range.contains(version)) {
  // do something
}
```

What I'm going to do next:

- support prerelease tags
- support range set chaining by ||
- support [advanced](https://github.com/npm/node-semver#advanced-range-syntax) range syntax (hyphen, caret, tilde, etc)
- make it constexpr if possible

Any suggestions and improvements are welcome.