### PR TITLE
Fix typo in name of library version constant

### DIFF
--- a/include/semver.hpp
+++ b/include/semver.hpp
@@ -800,7 +800,7 @@ constexpr bool satisfies(const version& ver, std::string_view str, satisfies_opt
 } // namespace semver::range
 
 // Version lib semver.
-inline constexpr auto semver_verion = version{SEMVER_VERSION_MAJOR, SEMVER_VERSION_MINOR, SEMVER_VERSION_PATCH};
+inline constexpr auto semver_version = version{SEMVER_VERSION_MAJOR, SEMVER_VERSION_MINOR, SEMVER_VERSION_PATCH};
 
 } // namespace semver
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -34,9 +34,9 @@
 
 using namespace semver;
 
-static_assert(semver_verion.major == SEMVER_VERSION_MAJOR);
-static_assert(semver_verion.minor == SEMVER_VERSION_MINOR);
-static_assert(semver_verion.patch == SEMVER_VERSION_PATCH);
+static_assert(semver_version.major == SEMVER_VERSION_MAJOR);
+static_assert(semver_version.minor == SEMVER_VERSION_MINOR);
+static_assert(semver_version.patch == SEMVER_VERSION_PATCH);
 
 static_assert(alignof(version) == 1);
 static_assert(alignof(prerelease) == 1);


### PR DESCRIPTION
Hello again, I noticed that the constant defining the version of the semver library itself contained a typo (`semver_verion` instead of `semver_version`).
Changing this would of course technically break code using the old name, but I don't think there are many projects that would actually be affected by this, so it should be fine.