### PR TITLE
Attempt to fix leading zero parsing.

### DIFF
--- a/include/semver.hpp
+++ b/include/semver.hpp
@@ -690,7 +690,6 @@ class version_parser {
       default:
         return failure(token.lexeme);
       }
-
     } while (stream.advanceIfMatch(token, token_type::hyphen) || stream.advanceIfMatch(token, token_type::letter) || stream.advanceIfMatch(token, token_type::digit));
 
     out = result;

--- a/include/semver.hpp
+++ b/include/semver.hpp
@@ -658,6 +658,7 @@ class version_parser {
   }
 
   SEMVER_CONSTEXPR from_chars_result parse_prerelease_identifier(std::string& out) {
+    bool first_char = true;
     std::string result;
     token token = stream.advance();
 
@@ -678,7 +679,7 @@ class version_parser {
         // 1.2.3-01b is valid as well, but
         // 1.2.3-01.alpha is not valid
 
-        if (is_leading_zero(digit)) {
+        if (first_char && is_leading_zero(digit)) {
           return failure(token.lexeme);
         }
 
@@ -688,6 +689,8 @@ class version_parser {
       default:
         return failure(token.lexeme);
       }
+
+      first_char = false;
     } while (stream.advanceIfMatch(token, token_type::hyphen) || stream.advanceIfMatch(token, token_type::letter) || stream.advanceIfMatch(token, token_type::digit));
 
     out = result;

--- a/include/semver.hpp
+++ b/include/semver.hpp
@@ -658,7 +658,6 @@ class version_parser {
   }
 
   SEMVER_CONSTEXPR from_chars_result parse_prerelease_identifier(std::string& out) {
-    bool first_char = true;
     std::string result;
     token token = stream.advance();
 
@@ -679,7 +678,9 @@ class version_parser {
         // 1.2.3-01b is valid as well, but
         // 1.2.3-01.alpha is not valid
 
-        if (first_char && is_leading_zero(digit)) {
+        // Only check for leading zero when digit is the first character of the
+        // prerelease identifier.
+        if (result.empty() && is_leading_zero(digit)) {
           return failure(token.lexeme);
         }
 
@@ -690,7 +691,6 @@ class version_parser {
         return failure(token.lexeme);
       }
 
-      first_char = false;
     } while (stream.advanceIfMatch(token, token_type::hyphen) || stream.advanceIfMatch(token, token_type::letter) || stream.advanceIfMatch(token, token_type::digit));
 
     out = result;

--- a/test/test_parse.cpp
+++ b/test/test_parse.cpp
@@ -102,10 +102,11 @@ TEST_CASE("parse") {
       std::string_view prerelease_tag;
     };
 
-    constexpr std::array<std::pair<std::string_view, version>, 3> versions = {{
+    constexpr std::array<std::pair<std::string_view, version>, 4> versions = {{
       {"0.0.1-alpha.128", {0, 0, 1, "alpha.128"}},
       {"1.2.3-alpha.beta.rc-45.42", {1, 2, 3, "alpha.beta.rc-45.42"}},
-      {"0.0.1-alpha-beta", {0, 0, 1, "alpha-beta"}}
+      {"0.0.1-alpha-beta", {0, 0, 1, "alpha-beta"}},
+      {"1.0.1-alpha.5-114-ga2f3905", {1, 0, 1, "alpha.5-114-ga2f3905"}}
     }};
 
     for (const auto& [version, expected]: versions) {


### PR DESCRIPTION
This change ensures that the `is_leading_zero` check only occurs for the first digit of a pre-release identifier not on every digit character of a pre-release identifier.

See issue: https://github.com/Neargye/semver/issues/53