### PR TITLE
build & test on OpenBSD

### DIFF
--- a/include/semver.hpp
+++ b/include/semver.hpp
@@ -78,6 +78,12 @@
 #define SEMVER_CONSTEXPR inline
 #endif
 
+#ifdef __OpenBSD__
+/* undef sys/types.h macro */
+#undef major
+#undef minor
+#endif
+
 namespace semver {
 
   namespace detail {


### PR DESCRIPTION
On OpenBSD, include iostream bring in sys/_types.h which have macro major and minor.
```
#if __BSD_VISIBLE
/* Major, minor numbers, dev_t's. */
#define major(x)        (((unsigned)(x) >> 8) & 0xff)
#define minor(x)        ((unsigned)((x) & 0xff) | (((x) & 0xffff0000) >> 8))
#define makedev(x,y)    ((dev_t)((((x) & 0xff) << 8) | ((y) & 0xff) | (((y) & 0xffff00) << 8)))
#endif
```

Which conflict with any major() or minor() in source.

```
In file included from /mnt/ext/_ports/pobj/semver-1.0.0-rc/semver-1.0.0-rc/example/basic_example.cpp:26:  
/mnt/ext/_ports/pobj/semver-1.0.0-rc/semver-1.0.0-rc/include/semver.hpp:146:25: error: expected member name or ';' after declaration specifiers                                               
  146 |     SEMVER_CONSTEXPR I1 major() const noexcept { return major_; }
      |     ~~~~~~~~~~~~~~~~~~~ ^              
/usr/include/sys/types.h:211:21: note: expanded from macro 'major'                                                                                                                            
  211 | #define major(x)        (((unsigned)(x) >> 8) & 0xff)                                                                                                                                 
      |                            ^                         
```

I guess the variable __BSD_VISIBLE is internal and shouldn't be changed. It's used in too many places.

Anything using semver shouldn't be using those macros and a #warnings would stop compilation if treated as an error.
But still, silently hiding these macros could lead to unexpected build errors in some corner cases which may never exist.

I'm worried, if this ever happens, that the error is so hard to find that it would be a nightmare for someone.
Note also that if someone ever wants to mix version comparison (without calling major/minor functions) and those macros it will have to use #pragma push_macro() / pop_macro() around the semver include to preserve them.

Let me know what you think, maybe add an option and call #warnings if it isn't defined on OpenBSD ?